### PR TITLE
Fix MySQL SSL warning

### DIFF
--- a/liferay.go
+++ b/liferay.go
@@ -54,7 +54,7 @@ func PostgreJDBC(address, port, database, user, password string) JDBC {
 func MysqlJDBC(address, port, database, user, password string) JDBC {
 	return JDBC{
 		Driver:   "jdbc.default.driverClassName=com.mysql.jdbc.Driver",
-		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mysql://%s:%s/%s?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false", address, port, database),
+		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mysql://%s:%s/%s?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false&useSSL=false", address, port, database),
 		User:     fmt.Sprintf("jdbc.default.username=%s", user),
 		Password: fmt.Sprintf("jdbc.default.password=%s", password),
 	}
@@ -71,7 +71,7 @@ func MysqlJDBC(address, port, database, user, password string) JDBC {
 func MysqlJDBCDXP(address, port, database, user, password string) JDBC {
 	return JDBC{
 		Driver:   "jdbc.default.driverClassName=com.mysql.jdbc.Driver",
-		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mysql://%s:%s/%s?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&useFastDateParsing=false&useUnicode=true", address, port, database),
+		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mysql://%s:%s/%s?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&useFastDateParsing=false&useUnicode=true&useSSL=false", address, port, database),
 		User:     fmt.Sprintf("jdbc.default.username=%s", user),
 		Password: fmt.Sprintf("jdbc.default.password=%s", password),
 	}


### PR DESCRIPTION
Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.