### PR TITLE
Remove useSSL from MariaDB JDBC URL

### DIFF
--- a/liferay.go
+++ b/liferay.go
@@ -69,7 +69,7 @@ func MysqlJDBC(address, port, database, user, password string) JDBC {
 func MariaDBJDBC(address, port, database, user, password string) JDBC {
 	return JDBC{
 		Driver:   "jdbc.default.driverClassName=org.mariadb.jdbc.Driver",
-		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mariadb://%s:%s/%s?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false&useSSL=false", address, port, database),
+		URL:      fmt.Sprintf("jdbc.default.url=jdbc:mariadb://%s:%s/%s?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false", address, port, database),
 		User:     fmt.Sprintf("jdbc.default.username=%s", user),
 		Password: fmt.Sprintf("jdbc.default.password=%s", password),
 	}


### PR DESCRIPTION
MariaDB JDBC driver (v1.1.9) included in DXP ignores "useSSL=false" and tries to connect with SSL